### PR TITLE
Implements logic for using the muscle_adipose_tissue model & fixes DICOM reading for pydicom >= 3.0.0

### DIFF
--- a/bin/C2C
+++ b/bin/C2C
@@ -51,15 +51,16 @@ def MuscleAdiposeTissuePipelineBuilder(args):
             muscle_adipose_tissue.MuscleAdiposeTissueComputeMetrics(),
             muscle_adipose_tissue_visualization.MuscleAdiposeTissueVisualizer(),
             muscle_adipose_tissue.MuscleAdiposeTissueH5Saver(),
+            muscle_adipose_tissue.MuscleAdiposeTissueNiftiSaver(),
             muscle_adipose_tissue.MuscleAdiposeTissueMetricsSaver(),
         ]
     )
     return pipeline
 
 
-def MuscleAdiposeTissueFullPipelineBuilder(args):
+def MuscleAdiposeTissueFullPipelineBuilder(path, args):
     pipeline = InferencePipeline(
-        [io.DicomFinder(args.input_path), MuscleAdiposeTissuePipelineBuilder(args)]
+        [io.DicomFinder(path), MuscleAdiposeTissuePipelineBuilder(args)]
     )
     return pipeline
 
@@ -269,6 +270,8 @@ def main():
     args = argument_parser().parse_args()
     if args.pipeline == "spine_muscle_adipose_tissue":
         process_3d(args, SpineMuscleAdiposeTissuePipelineBuilder)
+    elif args.pipeline == "muscle_adipose_tissue":
+        process_3d(args, MuscleAdiposeTissueFullPipelineBuilder)
     elif args.pipeline == "spine":
         process_3d(args, SpinePipelineBuilder)
     elif args.pipeline == "contrast_phase":

--- a/comp2comp/io/io.py
+++ b/comp2comp/io/io.py
@@ -96,7 +96,7 @@ class DicomToNifti(InferenceClass):
         if self.input_path.is_dir():
             # store a dcm object for retrieving dicom tags
             dcm_files = [d for d in os.listdir(self.input_path) if d.endswith('.dcm')]
-            inference_pipeline.dcm = pydicom.read_file(os.path.join(self.input_path, dcm_files[0]))
+            inference_pipeline.dcm = pydicom.dcmread(os.path.join(self.input_path, dcm_files[0]))
 
             ds = dicom_series_to_nifti(
                 self.input_path,

--- a/comp2comp/muscle_adipose_tissue/data.py
+++ b/comp2comp/muscle_adipose_tissue/data.py
@@ -84,7 +84,7 @@ class Dataset(k_utils.Sequence):
 
     def __getitem__(self, idx):
         files = self._files[idx * self._batch_size : (idx + 1) * self._batch_size]
-        dcms = [pydicom.read_file(f, force=True) for f in files]
+        dcms = [pydicom.dcmread(f, force=True) for f in files]
 
         xs = [(x.pixel_array + int(x.RescaleIntercept)).astype("float32") for x in dcms]
 


### PR DESCRIPTION
### **Implements logic for using the _muscle_adipose_tissue_ model**
This PR allows using the _muscle_adipose_tissue_ model, without the spine segmentation. The _muscle_adipose_tissue_ model uses by default the _abCT_v0.0.1_ segmentation model instead of the _stanford_v0.0.2_ segmentation model, used by default by the _spine_muscle_adipose_tissue_ model. Also, proper saving to NifTi format is added for the segmentation mask generated by the _muscle_adipose_tissue_ model, allowing to export it as a volume instead of single-slice h5 files.

### **Fixes DICOM reading for pydicom >= 3.0.0**
This PR also updates the DICOM file reading logic to ensure compatibility with pydicom version 3.0.0 and above.